### PR TITLE
Use HTMLConfluenceTranslator for html builder and JSONConfluenceBuilder.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Sphinx>=1.3.5
+docutils==0.12

--- a/sphinx_confluence/__init__.py
+++ b/sphinx_confluence/__init__.py
@@ -51,6 +51,7 @@ class JSONConfluenceBuilder(JSONHTMLBuilder):
 
     def __init__(self, app):
         super(JSONConfluenceBuilder, self).__init__(app)
+        self.translator_class = HTMLConfluenceTranslator
         self.warn('json_conf builder is deprecated and will be removed in future releases')
 
 
@@ -543,7 +544,7 @@ def setup(app):
     app.config.html_theme_path = [get_path()]
     app.config.html_theme = 'confluence'
     app.config.html_scaled_image_link = False
-    app.config.html_translator_class = 'sphinx_confluence.HTMLConfluenceTranslator'
+    app.set_translator("html", HTMLConfluenceTranslator)
     app.config.html_add_permalinks = ''
 
     jira_issue = JiraIssueRole('jira_issue', nodes.Inline)

--- a/sphinx_confluence/__init__.py
+++ b/sphinx_confluence/__init__.py
@@ -5,12 +5,15 @@ https://confluence.atlassian.com/display/DOC/Confluence+Storage+Format
 
 """
 
+from distutils.version import LooseVersion
 import os
 
 from docutils import nodes
 from docutils.parsers.rst import directives, Directive, roles
 from docutils.parsers.rst.directives import images
 from docutils.parsers.rst.roles import set_classes
+
+import sphinx
 from sphinx.builders.html import JSONHTMLBuilder
 from sphinx.locale import _
 from sphinx.writers.html import HTMLTranslator
@@ -51,7 +54,8 @@ class JSONConfluenceBuilder(JSONHTMLBuilder):
 
     def __init__(self, app):
         super(JSONConfluenceBuilder, self).__init__(app)
-        self.translator_class = HTMLConfluenceTranslator
+        if LooseVersion(sphinx.__version__) >= LooseVersion("1.4"):
+            self.translator_class = HTMLConfluenceTranslator
         self.warn('json_conf builder is deprecated and will be removed in future releases')
 
 
@@ -544,7 +548,10 @@ def setup(app):
     app.config.html_theme_path = [get_path()]
     app.config.html_theme = 'confluence'
     app.config.html_scaled_image_link = False
-    app.set_translator("html", HTMLConfluenceTranslator)
+    if LooseVersion(sphinx.__version__) >= LooseVersion("1.4"):
+        app.set_translator("html", HTMLConfluenceTranslator)
+    else:
+        app.config.html_translator_class = 'sphinx_confluence.HTMLConfluenceTranslator'
     app.config.html_add_permalinks = ''
 
     jira_issue = JiraIssueRole('jira_issue', nodes.Inline)

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    {py27,py34,py35}-sphinx{13,14}
+    {py27,py34,py35}-sphinx{13,14,15}
 
 [testenv]
 deps =
     sphinx13: Sphinx>=1.3,<1.4
     sphinx14: Sphinx>=1.4
+    sphinx15: Sphinx>=1.5
 commands = sphinx-build -b html -d {envtmpdir}/doctrees -C -D master_doc=example -D extensions=sphinx_confluence,sphinx.ext.todo tests {envtmpdir}


### PR DESCRIPTION
In order to use the sphinx-confluence module with sphinx 1.5.1, i had to modify it:
- for the `html` builder to output Confluence Storage Format files, the `HTMLConfluenceTranslator` had to be set as a translator for the `html` builder on the `app` instance in the initialization of the extension.
- the `JSONConfluenceBuilder` was not outputting Confluence Storage Format until i set his `translator_class` to the `HTMLConfluenceTranslator` class. It is probably due to the following [code](https://github.com/sphinx-doc/sphinx/blob/69e64cfe26e3df11e046071b5c43928828d71809/sphinx/builders/html.py#L183) in `StandaloneHTMLBuilder` of Sphinx :
```
    def init_translator_class(self):
        # type: () -> None
        if self.translator_class is None:
            if self.config.html_use_smartypants:
                self.translator_class = SmartyPantsHTMLTranslator
            else:
                self.translator_class = HTMLTranslator
```
If the translator class is null, then a default HTML translator is returned. This is what happen without this patch when using the `json_conf` builder.
If these patches are not wrong it would be fine to include them, but i fear that it brokes with older versions of Sphinx, let me know.

Thanks for your time,
Best regards.
