### PR TITLE
JSONHTMLBuilder location changed in newer Sphinx's

### DIFF
--- a/sphinx_confluence/__init__.py
+++ b/sphinx_confluence/__init__.py
@@ -14,7 +14,10 @@ from docutils.parsers.rst.directives import images
 from docutils.parsers.rst.roles import set_classes
 
 import sphinx
-from sphinx.builders.html import JSONHTMLBuilder
+try:
+    from sphinx.builders.html import JSONHTMLBuilder
+except ImportError:
+    from sphinxcontrib.serializinghtml import JSONHTMLBuilder
 from sphinx.directives.code import CodeBlock
 from sphinx.locale import _
 from sphinx.writers.html import HTMLTranslator


### PR DESCRIPTION
Fixes a defect when running against Sphinx. Not sure which version 