### PR TITLE
Add Sphinx Extension PyPi classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
+        'Framework :: Sphinx :: Extension',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).